### PR TITLE
fix runtime crash: you can't cast long to String

### DIFF
--- a/src/main/java/convex/java/Convex.java
+++ b/src/main/java/convex/java/Convex.java
@@ -191,7 +191,7 @@ public class Convex {
 		req.put("accountKey", keyPair.getAccountKey().toHexString());
 		String json=JSON.toPrettyString(req);
 		Map<String,Object> response= doPost(url+"/api/v1/createAccount",json);
-		Address address=Address.parse((String)response.get("address"));
+		Address address=Address.parse(response.get("address").toString());
 		if (address==null) throw new Error("Account creation failed: "+response);
 		return address;
 	}


### PR DESCRIPTION
Tests was not passing without this and I also checked it with

```java
Convex convex = Convex.connect("https://convex.world");
Address address = convex.useNewAccount(30000);
AKeyPair keyPair = convex.getKeyPair();
Map<String, Object> queryResult = convex.queryAccount();
System.out.println(queryResult);
```